### PR TITLE
Убрал поле `clientId` из тела запроса в orchestrator и data-aggregator

### DIFF
--- a/data-aggregator/src/main/java/com/ebito/data_aggregator/api/controller/DataAggregatorController.java
+++ b/data-aggregator/src/main/java/com/ebito/data_aggregator/api/controller/DataAggregatorController.java
@@ -19,6 +19,7 @@ public class DataAggregatorController implements DataAggregatorApi {
 
     @Override
     public ResponseEntity<PrintedGuids> generatePrintForm(final String clientId, final PrintFormGenerationRequest request) {
+        request.setClientId(clientId);
         final var response = commonService.selectPrintForm(request);
         return ResponseEntity.ok(response);
     }

--- a/data-aggregator/src/main/java/com/ebito/data_aggregator/rabbitmq/model/PrintFormGenerationRequest.java
+++ b/data-aggregator/src/main/java/com/ebito/data_aggregator/rabbitmq/model/PrintFormGenerationRequest.java
@@ -24,9 +24,7 @@ public class PrintFormGenerationRequest {
     @NotNull(message = "Document code must not be null")
     private String documentCode;
 
-    @Schema(description = "Идентификатор клиента",
-            example = "1")
-    @NotNull(message = "Client id must not be null")
+    @Schema(hidden = true)
     private String clientId;
 
     @Schema(description = "Канал запроса на генерацию документа")
@@ -44,4 +42,11 @@ public class PrintFormGenerationRequest {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     @NotNull(message = "Date to must not be null")
     private LocalDate dateTo;
+
+    public PrintFormGenerationRequest(String documentCode, Channel channel, LocalDate dateFrom, LocalDate dateTo) {
+        this.documentCode = documentCode;
+        this.channel = channel;
+        this.dateFrom = dateFrom;
+        this.dateTo = dateTo;
+    }
 }

--- a/orchestrator/src/main/java/com/ebito/orchestrator/api/controller/OrchestratorController.java
+++ b/orchestrator/src/main/java/com/ebito/orchestrator/api/controller/OrchestratorController.java
@@ -32,6 +32,7 @@ public class OrchestratorController implements OrchestratorApi {
 
     @Override
     public ResponseEntity<Void> generateDocument(final String clientId, final PrintFormGenerationRequest request) {
+        request.setClientId(clientId);
         if (isAsyncConnectEnabled) {
             rabbitMqSender.send(request);
         } else {

--- a/orchestrator/src/main/java/com/ebito/orchestrator/api/controller/request/PrintFormGenerationRequest.java
+++ b/orchestrator/src/main/java/com/ebito/orchestrator/api/controller/request/PrintFormGenerationRequest.java
@@ -22,9 +22,7 @@ public class PrintFormGenerationRequest {
     @NotNull(message = "Document code must not be null")
     private String documentCode;
 
-    @Schema(description = "Идентификатор клиента",
-            example = "1")
-    @NotNull(message = "Client id must not be null")
+    @Schema(hidden = true)
     private String clientId;
 
     @Schema(description = "Канал запроса на генерацию документа")


### PR DESCRIPTION
Убрал дублирование поля clientId, оно передавалось и как path variable, и в теле запроса (причем значение в пути url игнорировалось в программе).

Теперь clientId передается только в url
 